### PR TITLE
Add scaffold, move rspec-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,6 @@ group :production, :staging do
 end
 
 group :test do
-  gem 'rspec-rails'
   gem 'factory_girl_rails', require: false
   gem 'faker'
   gem 'capybara'
@@ -40,6 +39,7 @@ group :test do
 end
 
 group :development, :test do
+  gem 'rspec-rails'
   gem 'pry-rails'
   gem 'pry-byebug'
   gem 'better_errors'

--- a/spec/controllers/api/authorizations_controller_spec.rb
+++ b/spec/controllers/api/authorizations_controller_spec.rb
@@ -1,0 +1,2 @@
+describe Api::AuthorizationsController do
+end


### PR DESCRIPTION
Needed to 'rake spec' can be run, which avoids an exception that is
thrown with 'rspec'
