### PR TITLE
Call Rollbar instead of serializing exceptions

### DIFF
--- a/app/jobs/notify_failure_job.rb
+++ b/app/jobs/notify_failure_job.rb
@@ -11,4 +11,9 @@ class NotifyFailureJob < ActiveJob::Base
 
     RestClient.post(slack_url, payload.to_json)
   end
+
+  def self.handle_exception(exception, slack_url)
+    Rollbar.error(exception)
+    perform_later(slack_url)
+  end
 end

--- a/app/jobs/notify_failure_job.rb
+++ b/app/jobs/notify_failure_job.rb
@@ -1,7 +1,7 @@
 class NotifyFailureJob < ActiveJob::Base
   queue_as :notify_failure
 
-  def perform(exception, slack_url)
+  def perform(slack_url)
     payload = {
       text: [
         "Sorry, something went wrong while asking Uber for a ride.",

--- a/app/jobs/notify_success_job.rb
+++ b/app/jobs/notify_success_job.rb
@@ -9,19 +9,17 @@ class NotifySuccessJob < ActiveJob::Base
     begin
       RestClient.post(slack_url, payload.to_json)
     rescue RestClient::Exception => e
-      Rollbar.error(e)
-      NotifyFailureJob.perform_later(slack_url)
+      NotifyFailureJob.handle_exception(e, slack_url)
     end
   end
 
-  def format_200_ride_request_response(origin, destination, eta)
+  def format_200_ride_request_response(origin, destination, _eta)
     ["Asked Uber for a driver",
      "to take you from #{origin} to #{destination}.",
     ].join(" ")
   end
 
-  def on_failure(exception, origin, destination, eta, slack_url)
-    Rollbar.error(exception)
-    NotifyFailureJob.perform_later(slack_url)
+  def on_failure(exception, _origin, _destination, _eta, slack_url)
+    NotifyFailureJob.handle_exception(exception, slack_url)
   end
 end

--- a/app/jobs/notify_success_job.rb
+++ b/app/jobs/notify_success_job.rb
@@ -8,8 +8,9 @@ class NotifySuccessJob < ActiveJob::Base
 
     begin
       RestClient.post(slack_url, payload.to_json)
-    rescue => e
-      NotifyFailureJob.perform_later(e, slack_url)
+    rescue RestClient::Exception => e
+      Rollbar.error(e)
+      NotifyFailureJob.perform_later(slack_url)
     end
   end
 
@@ -20,6 +21,7 @@ class NotifySuccessJob < ActiveJob::Base
   end
 
   def on_failure(exception, origin, destination, eta, slack_url)
-    NotifyFailureJob.perform_later(exception, slack_url)
+    Rollbar.error(exception)
+    NotifyFailureJob.perform_later(slack_url)
   end
 end

--- a/app/jobs/ride_job.rb
+++ b/app/jobs/ride_job.rb
@@ -24,8 +24,7 @@ class RideJob < ActiveJob::Base
         product_id
       )
     rescue RestClient::Exception => e
-      Rollbar.error(e)
-      NotifyFailureJob.perform_later(slack_url)
+      NotifyFailureJob.handle_exception(e, slack_url)
       return
     end
 
@@ -40,8 +39,7 @@ class RideJob < ActiveJob::Base
       ride = Ride.find(ride_hash['id'])
       ride.update!(request_id: ride_response['request_id'])
     rescue RestClient::Exception => e
-      Rollbar.error(e)
-      NotifyFailureJob.perform_later(slack_url)
+      NotifyFailureJob.handle_exception(e, slack_url)
       return
     end
   end
@@ -86,7 +84,6 @@ class RideJob < ActiveJob::Base
         product_id,
         slack_url
       )
-    Rollbar.error(exception)
-    NotifyFailureJob.perform_later(slack_url)
+    NotifyFailureJob.handle_exception(e, slack_url)
   end
 end

--- a/app/jobs/ride_job.rb
+++ b/app/jobs/ride_job.rb
@@ -2,17 +2,17 @@ class RideJob < ActiveJob::Base
   queue_as :ride
 
   def perform(
-    bearer_header,
-    ride_hash,
-    origin_lat,
-    origin_lng,
-    destination_lat,
-    destination_lng,
-    origin_name,
-    destination_name,
-    product_id,
-    slack_url
-  )
+        bearer_header,
+        ride_hash,
+        origin_lat,
+        origin_lng,
+        destination_lat,
+        destination_lng,
+        origin_name,
+        destination_name,
+        product_id,
+        slack_url
+      )
 
     begin
       ride_response = self.request_ride!(
@@ -23,8 +23,9 @@ class RideJob < ActiveJob::Base
         destination_lng,
         product_id
       )
-    rescue => e
-      NotifyFailureJob.perform_later(e, slack_url)
+    rescue RestClient::Exception => e
+      Rollbar.error(e)
+      NotifyFailureJob.perform_later(slack_url)
       return
     end
 
@@ -38,52 +39,54 @@ class RideJob < ActiveJob::Base
     begin
       ride = Ride.find(ride_hash['id'])
       ride.update!(request_id: ride_response['request_id'])
-    rescue => e
-      NotifyFailureJob.perform_later(e, slack_url)
+    rescue RestClient::Exception => e
+      Rollbar.error(e)
+      NotifyFailureJob.perform_later(slack_url)
       return
     end
   end
 
   def request_ride!(
-    bearer_header,
-    origin_lat,
-    origin_lng,
-    destination_lat,
-    destination_lng,
-    product_id
-  )
-      body = {
-        start_latitude: origin_lat,
-        start_longitude: origin_lng,
-        end_latitude: destination_lat,
-        end_longitude: destination_lng,
-        product_id: product_id
-      }
-
-      response = RestClient.post(
-        "#{ENV["uber_base_url"]}/v1/requests",
-        body.to_json,
-        authorization: bearer_header,
-        "Content-Type" => :json,
-        accept: 'json'
+        bearer_header,
+        origin_lat,
+        origin_lng,
+        destination_lat,
+        destination_lng,
+        product_id
       )
+    body = {
+      start_latitude: origin_lat,
+      start_longitude: origin_lng,
+      end_latitude: destination_lat,
+      end_longitude: destination_lng,
+      product_id: product_id
+    }
+
+    response = RestClient.post(
+      "#{ENV["uber_base_url"]}/v1/requests",
+      body.to_json,
+      authorization: bearer_header,
+      "Content-Type" => :json,
+      accept: 'json'
+    )
 
     JSON.parse(response.body)
   end
 
   def on_failure(
-    exception,
-    bearer_header,
-    ride,
-    origin_lat,
-    origin_lng,
-    destination_lat,
-    destination_lng,
-    origin_name,
-    destination_name,
-    product_id,
-    slack_url
-  )
-    NotifyFailureJob.perform_later(exception, slack_url)
+        exception,
+        bearer_header,
+        ride,
+        origin_lat,
+        origin_lng,
+        destination_lat,
+        destination_lng,
+        origin_name,
+        destination_name,
+        product_id,
+        slack_url
+      )
+    Rollbar.error(exception)
+    NotifyFailureJob.perform_later(slack_url)
   end
 end


### PR DESCRIPTION
RestClient::Exception isn't an ActiveRecord object, and so can't be
serialized by ActiveJob. So, we stop trying, and just send the info to
Rollbar, and let the failure job just take care of notifying Slack.
