### PR TITLE
Add developer guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,45 +65,17 @@ A help manual is available with the 'help' command:
 #### Support
 Get more info about support [here](support.md).
 
-## Contributing
+### Contributing
+We'd love to have you contribute! Read more [here](develop.md)
 
-#### Slack Channels
+### Slack Channels
 
 Join our [Slack Channel](https://uberonslack.com/static_pages/join_slack_team) to
 
-- discuss about this project
+- get help with any issues you may have
+- discuss this project
 - throw in ideas of new features
 - or simply report/fix bugs if you see any
-
-#### New features / bug fixes
-
-1. Fork this repo
-2. Create feature branch
-3. Push to your branch
-4. Create Pull Request from your branch
-
-**If your PR would require sandbox testing, continue to follow the below steps**
-
-5. Name your app as _uber-on-slack-sandbox-your-identifier_ (e.g. uber-on-slack-sandbox-app-academy).
-  * This name would be used for your Heroku app, and Registration on Uber and Slack.
-6. Go to [Uber Developer] to register an app on Uber
-  1. Set all redirect URIs as `https://_uber-on-slack-sandbox-your-identifier_.herokuapp.com/api/connect_uber`
-  2. Point privacy policy to your github repo
-7. Go to [Slack App API] to create an app
-  1. Set all redirect URIs as `https://_uber-on-slack-sandbox-your-identifier_.com/api/connect_slack`
-  2. Create a slash command, and name is as `/uber-pr`
-8. Click this button in your forked repo to deploy
-  * [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/username/repo)
-9. Paste your heroku app URL in the description, and specify what the PR is about.
-10. That's it.
-
-[Uber Developer]: https://developer.uber.com/dashboard/create
-[Slack App API]: https://api.slack.com/apps/new
-
-#### Encounter issues?
-
-If you encounter any kind of issue, you can simply report it on github or discuss on our 
-[Slack Channel](https://uberonslack.com/static_pages/join_slack_team)
 
 ## License
 Uber on Slack is open-source and free to distribute or modify under the

--- a/develop.md
+++ b/develop.md
@@ -17,34 +17,24 @@ If your changes would require more extensive testing (e.g. accessing a new Uber 
 you may want to setup a sandbox version of the app.
 
 1. Fork this Repo.
-2. Host the app (we use Heroku) as _uber-on-slack-sandbox-your-identifier_ (e.g. uber-on-slack-sandbox-app-academy).
-  * This name would be used for your Heroku app, and Registration on Uber and Slack.
-3. Go to [Uber Developer] to register an app on Uber
+2. Go to [Uber Developer] to register an app on Uber
   1. Set all redirect URIs as `https://uber-on-slack-sandbox-your-identifier.herokuapp.com/api/connect_uber`
   2. Point privacy policy to your github repo
-4. Go to [Slack App API] to create an app
+3. Go to [Slack App API] to create an app
   1. Set all redirect URIs as `https://uber-on-slack-sandbox-your-identifier.com/api/connect_slack`
   2. Create a slash command, and name it as `/uber-your-identifier`
-5. You will need the Uber client_id and client_secret, and the slack slash command verification token.
-  1. We use the [Figaro](https://github.com/laserlemon/figaro) gem to manage client secrets.
-  2. Run `bundle exec figaro install`, which will generate an `application.yaml` file to store your secrets in. It should look like this:
-  ```yaml
-    # TODO: @Edmundleex, can you put your file here (with secrets censored), since this is just my best guess? 
-    # I think you also have a redis URI that's been breaking for me locally, I'm not sure what to do with that.
-    uber_client_id: "your id"
-    uber_client_secret: "your secret"
-    uber_base_url:   "https://sandbox-api.uber.com/"
-    slack_app_token: "your token"
-  ```
-  3. Run `figaro heroku:set -e production` to push your keys to your production app. (You may need to have installed the Heroku CLI toolkit first)
-6. Deploy the app to Heroku
+4. You will need the Uber client_id and client_secret, and the slack slash command verification token.
+5. Host the app (we use [Heroku](https://dashboard.heroku.com/new)) as _uber-on-slack-sandbox-your-identifier_ (e.g. uber-on-slack-sandbox-app-academy).
+  1. After creating the app, on the resources tab under Add-ons, add `Redis to Go`. (This will automatically add its key to Heroku's config.
+  2. Under `Settings > Config Vars` add the following key-value pairs:
+     * 	slack_app_token
+     * 	uber_client_secret
+     * 	uber_client_id
+     * 	uber_base_url : https://sanbox-api.uber.com/
+  3. Deploy the app, either by linking your github account or using the command-line tools Heroku provides.
+
 
 <!--- 
- 8. Click this button in your forked repo to deploy
-  * [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/username/repo)
-  (@cchuang) This button wasn't working for me; but I had other problems like missing secrets too so I don't know.
-9. Paste your heroku app URL in the description, and specify what the PR is about.
-10. That's it.
 10. Activate your app in a Slack Channel? 
 -->
 

--- a/develop.md
+++ b/develop.md
@@ -1,0 +1,47 @@
+## Contributing
+We love any contributions! If you have any bug fixes, or would like to add new features:
+1. Fork this repo
+2. Create feature branch
+3. Push to your branch
+4. Create Pull Request from your branch to the core project's master branch.
+
+### Getting Started
+
+Join our [Slack Channel](https://uberonslack.com/static_pages/join_slack_team) for
+help or discussion.
+
+Read [this](doc/structure.md) for an overview of the codebase.
+
+If your changes would require more extensive testing (e.g. accessing a new Uber API endpoint),
+you may want to setup a sandbox version of the app.
+
+1. Fork this Repo.
+5. Host the app (we use Heroku) as _uber-on-slack-sandbox-your-identifier_ (e.g. uber-on-slack-sandbox-app-academy).
+  * This name would be used for your Heroku app, and Registration on Uber and Slack.
+6. Go to [Uber Developer] to register an app on Uber
+  1. Set all redirect URIs as `https://uber-on-slack-sandbox-your-identifier.herokuapp.com/api/connect_uber`
+  2. Point privacy policy to your github repo
+7. Go to [Slack App API] to create an app
+  1. Set all redirect URIs as `https://uber-on-slack-sandbox-your-identifier.com/api/connect_slack`
+  2. Create a slash command, and name it as `/uber-your-identifier`
+8. You will need the Uber client_id and client_secret, and the slack slash command verification token.
+  1. We use the [Figaro](https://github.com/laserlemon/figaro) gem to manage client secrets.
+  2. Run `bundle exec figaro install`, which will generate an `application.yaml` file to store your secrets in. It should look like this:
+  ```yaml
+    # TODO: @Edmundleex, can you put your file here (with secrets censored), since this is just my best guess? I think you also have a redis URI that's been breaking for me locally, I'm not sure what to do with that.
+    uber_client_id: "your id"
+    uber_client_secret: "your secret"
+    uber_base_url:   "https://sandbox-api.uber.com/"
+    slack_app_token: "your token"
+  ```
+  3. Run `figaro heroku:set -e production` to push your keys to your production app. (You may need to have installed the Heroku CLI toolkit first)
+9. Deploy the app to Heroku
+<!-- 8. Click this button in your forked repo to deploy
+  * [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/username/repo)
+  (@cchuang) This button wasn't working for me; but I had other problems like missing secrets too so I don't know.
+9. Paste your heroku app URL in the description, and specify what the PR is about.
+10. That's it.
+10. Activate your app in a Slack Channel? -->
+
+[Uber Developer]: https://developer.uber.com/dashboard/create
+[Slack App API]: https://api.slack.com/apps/new

--- a/develop.md
+++ b/develop.md
@@ -1,5 +1,6 @@
 ## Contributing
 We love any contributions! If you have any bug fixes, or would like to add new features:
+
 1. Fork this repo
 2. Create feature branch
 3. Push to your branch
@@ -16,32 +17,36 @@ If your changes would require more extensive testing (e.g. accessing a new Uber 
 you may want to setup a sandbox version of the app.
 
 1. Fork this Repo.
-5. Host the app (we use Heroku) as _uber-on-slack-sandbox-your-identifier_ (e.g. uber-on-slack-sandbox-app-academy).
+2. Host the app (we use Heroku) as _uber-on-slack-sandbox-your-identifier_ (e.g. uber-on-slack-sandbox-app-academy).
   * This name would be used for your Heroku app, and Registration on Uber and Slack.
-6. Go to [Uber Developer] to register an app on Uber
+3. Go to [Uber Developer] to register an app on Uber
   1. Set all redirect URIs as `https://uber-on-slack-sandbox-your-identifier.herokuapp.com/api/connect_uber`
   2. Point privacy policy to your github repo
-7. Go to [Slack App API] to create an app
+4. Go to [Slack App API] to create an app
   1. Set all redirect URIs as `https://uber-on-slack-sandbox-your-identifier.com/api/connect_slack`
   2. Create a slash command, and name it as `/uber-your-identifier`
-8. You will need the Uber client_id and client_secret, and the slack slash command verification token.
+5. You will need the Uber client_id and client_secret, and the slack slash command verification token.
   1. We use the [Figaro](https://github.com/laserlemon/figaro) gem to manage client secrets.
   2. Run `bundle exec figaro install`, which will generate an `application.yaml` file to store your secrets in. It should look like this:
   ```yaml
-    # TODO: @Edmundleex, can you put your file here (with secrets censored), since this is just my best guess? I think you also have a redis URI that's been breaking for me locally, I'm not sure what to do with that.
+    # TODO: @Edmundleex, can you put your file here (with secrets censored), since this is just my best guess? 
+    # I think you also have a redis URI that's been breaking for me locally, I'm not sure what to do with that.
     uber_client_id: "your id"
     uber_client_secret: "your secret"
     uber_base_url:   "https://sandbox-api.uber.com/"
     slack_app_token: "your token"
   ```
   3. Run `figaro heroku:set -e production` to push your keys to your production app. (You may need to have installed the Heroku CLI toolkit first)
-9. Deploy the app to Heroku
-<!-- 8. Click this button in your forked repo to deploy
+6. Deploy the app to Heroku
+
+<!--- 
+ 8. Click this button in your forked repo to deploy
   * [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/username/repo)
   (@cchuang) This button wasn't working for me; but I had other problems like missing secrets too so I don't know.
 9. Paste your heroku app URL in the description, and specify what the PR is about.
 10. That's it.
-10. Activate your app in a Slack Channel? -->
+10. Activate your app in a Slack Channel? 
+-->
 
 [Uber Developer]: https://developer.uber.com/dashboard/create
 [Slack App API]: https://api.slack.com/apps/new


### PR DESCRIPTION
Move the expanding development instructions into a separate file from the general readme. This is incomplete; I could  use an example of a complete `application.yaml` file to be sure I'm not missing any keys.
