### PR TITLE
Fix "Fork me on github" link

### DIFF
--- a/app/views/static_pages/root.html.erb
+++ b/app/views/static_pages/root.html.erb
@@ -27,7 +27,7 @@ License URL: http://creativecommons.org/licenses/by/3.0/
 <body>
 <!--header start here-->
 
-<a href="https://github.com/you"><img style="position: absolute; top: 0; left: 0; border: 0;" src="https://camo.githubusercontent.com/567c3a48d796e2fc06ea80409cc9dd82bf714434/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f6c6566745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_left_darkblue_121621.png"></a>
+<a href="https://github.com/appacademy/uber_slack"><img style="position: absolute; top: 0; left: 0; border: 0;" src="https://camo.githubusercontent.com/567c3a48d796e2fc06ea80409cc9dd82bf714434/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f6c6566745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_left_darkblue_121621.png"></a>
 
 <div class="header">
 	<div class="container">


### PR DESCRIPTION
Link was not correct, now it leads to appacademy/uber_slack github page.
